### PR TITLE
Fix wan module import

### DIFF
--- a/gradio/i2v_14B_singleGPU.py
+++ b/gradio/i2v_14B_singleGPU.py
@@ -2,6 +2,7 @@
 import argparse
 import gc
 import os.path as osp
+import os
 import sys
 import warnings
 
@@ -10,7 +11,7 @@ import gradio as gr
 warnings.filterwarnings('ignore')
 
 # Model
-sys.path.insert(0, '/'.join(osp.realpath(__file__).split('/')[:-2]))
+sys.path.insert(0, os.path.sep.join(osp.realpath(__file__).split(os.path.sep)[:-2]))
 import wan
 from wan.configs import MAX_AREA_CONFIGS, WAN_CONFIGS
 from wan.utils.prompt_extend import DashScopePromptExpander, QwenPromptExpander

--- a/gradio/t2i_14B_singleGPU.py
+++ b/gradio/t2i_14B_singleGPU.py
@@ -1,6 +1,7 @@
 # Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
 import argparse
 import os.path as osp
+import os
 import sys
 import warnings
 
@@ -9,7 +10,7 @@ import gradio as gr
 warnings.filterwarnings('ignore')
 
 # Model
-sys.path.insert(0, '/'.join(osp.realpath(__file__).split('/')[:-2]))
+sys.path.insert(0, os.path.sep.join(osp.realpath(__file__).split(os.path.sep)[:-2]))
 import wan
 from wan.configs import WAN_CONFIGS
 from wan.utils.prompt_extend import DashScopePromptExpander, QwenPromptExpander

--- a/gradio/t2v_1.3B_singleGPU.py
+++ b/gradio/t2v_1.3B_singleGPU.py
@@ -1,6 +1,7 @@
 # Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
 import argparse
 import os.path as osp
+import os
 import sys
 import warnings
 
@@ -9,7 +10,7 @@ import gradio as gr
 warnings.filterwarnings('ignore')
 
 # Model
-sys.path.insert(0, '/'.join(osp.realpath(__file__).split('/')[:-2]))
+sys.path.insert(0, os.path.sep.join(osp.realpath(__file__).split(os.path.sep)[:-2]))
 import wan
 from wan.configs import WAN_CONFIGS
 from wan.utils.prompt_extend import DashScopePromptExpander, QwenPromptExpander

--- a/gradio/t2v_14B_singleGPU.py
+++ b/gradio/t2v_14B_singleGPU.py
@@ -1,6 +1,7 @@
 # Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
 import argparse
 import os.path as osp
+import os
 import sys
 import warnings
 
@@ -9,7 +10,7 @@ import gradio as gr
 warnings.filterwarnings('ignore')
 
 # Model
-sys.path.insert(0, '/'.join(osp.realpath(__file__).split('/')[:-2]))
+sys.path.insert(0, os.path.sep.join(osp.realpath(__file__).split(os.path.sep)[:-2]))
 import wan
 from wan.configs import WAN_CONFIGS
 from wan.utils.prompt_extend import DashScopePromptExpander, QwenPromptExpander


### PR DESCRIPTION
Currently all the `import wan` lines in gradio apps fail because the path insertion assumes unix-like paths. instead of using `/`, used the `os.path.sep`, which works cross platform, making it work on Windows