### PR TITLE
update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ imageio-ffmpeg
 flash_attn
 gradio>=5.0.0
 numpy==1.24.4
+einops


### PR DESCRIPTION
einops seems missing when installing requirements.txt on windows 