### PR TITLE
Update text2video.py to reduce GPU memory by emptying cache

### DIFF
--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -261,7 +261,6 @@ class WanT2V:
         if offload_model:
             gc.collect()
             torch.cuda.synchronize()
-            torch.cuda.empty_cache()
         if dist.is_initialized():
             dist.barrier()
 

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -252,6 +252,7 @@ class WanT2V:
             x0 = latents
             if offload_model:
                 self.model.cpu()
+                torch.cuda.empty_cache()
             if self.rank == 0:
                 videos = self.vae.decode(x0)
 
@@ -260,6 +261,7 @@ class WanT2V:
         if offload_model:
             gc.collect()
             torch.cuda.synchronize()
+            torch.cuda.empty_cache()
         if dist.is_initialized():
             dist.barrier()
 


### PR DESCRIPTION
If offload_model is set, empty_cache() must be called after the model is moved to CPU to actually free the GPU. I verified on a RTX 4090 that without calling empty_cache the model remains in memory and the subsequent vae decoding never finishes.