### PR TITLE
Adding simple Gradio authorization in initial demo screen

### DIFF
--- a/gradio/t2v_1.3B_singleGPU.py
+++ b/gradio/t2v_1.3B_singleGPU.py
@@ -204,4 +204,7 @@ if __name__ == '__main__':
     print("done", flush=True)
 
     demo = gradio_interface()
-    demo.launch(server_name="0.0.0.0", share=False, server_port=7860)
+    if os.environ['WAN_USER'] and os.environ['WAN_PWD']:
+        demo.launch(server_name="0.0.0.0", share=False, server_port=7860, auth=(os.environ['WAN_USER'], os.environ['WAN_PWD']))
+    else:
+        demo.launch(server_name="0.0.0.0", share=False, server_port=7860)


### PR DESCRIPTION
Hi,
For tests of WAN from multiple locations, I need to expose the Gradio UI on the Internet.
So, it has to be minimally protected with at least 1 same userid / password for all testers.

So, I activated the simple Gradio authentication when 2 ENV vars are present: WAN_USER & WAN PWD. The UI remains open as today when those vars are not present.

See https://www.gradio.app/guides/sharing-your-app#authentication for details

See commit diff for the corresponding code.

I'll be happy to add same code to other Gradio demo scripts when you accept this PR.

Best,

Didier