### PR TITLE
Adding env variables for parametrized Gradio login

### DIFF
--- a/gradio/t2v_1.3B_singleGPU.py
+++ b/gradio/t2v_1.3B_singleGPU.py
@@ -204,4 +204,8 @@ if __name__ == '__main__':
     print("done", flush=True)
 
     demo = gradio_interface()
-    demo.launch(server_name="0.0.0.0", share=False, server_port=7860)
+    if "WAN_USER" in os.environ and "WAN_PWD" in os.environ:
+        demo.launch(server_name="0.0.0.0", share=False, server_port=7860,
+                    auth=(os.environ["WAN_USER"], os.environ["WAN_PWD"]))
+    else:
+        demo.launch(server_name="0.0.0.0", share=False, server_port=7860)


### PR DESCRIPTION
For tests of WAN from multiple locations, the Gradio UI is currently open on the Internet. So, it has to be minimally protected with at least 1 same userid / password for all testers.

So, this PR activates the simple Gradio authentication when 2 ENV vars are present: WAN_USER & WAN PWD. The UI remains open as today when those vars are not present. Those env vars can be set externally at container start in docker run command when Wan is containerized,

See https://www.gradio.app/guides/sharing-your-app#authentication for details

See commit diff for the corresponding code.

I'll be happy to add same code to other Gradio demo scripts when you accept this PR.

Best,

Didier