### PR TITLE
add wheel and packaging to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ imageio-ffmpeg
 flash_attn
 gradio>=5.0.0
 numpy>=1.23.5,<2
+wheel
+packaging


### PR DESCRIPTION
When installing `requirements.txt` with a fresh python install, the build process fails with the error `ModuleNotFoundError: No module named 'torch'`. 

See https://github.com/Wan-Video/Wan2.1/issues/119 for reports of others running into this issue.

The root cause is that the `wheel` and `packaging` python packages are not included by default. To fix this, they need to be added to the `requirements.txt` file.

This error can be duplicated with `asdf` by trying the following:

```
git clone https://github.com/Wan-Video/Wan2.1.git
cd Wan2.1

asdf install python 3.12.8
asdf set python 3.12.8

pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
pip install -r requirements.txt
```

The above will fail to build. However, if `pip install wheel packaging` is run, the `pip install -r requirements.txt` command will then complete successfully.