### PR TITLE
Fixed the issue that the generated MP4 file name is not supported under Windows

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -384,7 +384,7 @@ def generate(args):
             formatted_prompt = args.prompt.replace(" ", "_").replace("/",
                                                                      "_")[:50]
             suffix = '.png' if "t2i" in args.task else '.mp4'
-            safe_size = args.size.replace("*", "x")
+            safe_size = args.size.replace("*", "x") if os.name == 'nt' else args.size
             args.save_file = f"{args.task}_{safe_size}_{args.ulysses_size}_{args.ring_size}_{formatted_prompt}_{formatted_time}" + suffix
 
         if "t2i" in args.task:

--- a/generate.py
+++ b/generate.py
@@ -384,7 +384,8 @@ def generate(args):
             formatted_prompt = args.prompt.replace(" ", "_").replace("/",
                                                                      "_")[:50]
             suffix = '.png' if "t2i" in args.task else '.mp4'
-            args.save_file = f"{args.task}_{args.size}_{args.ulysses_size}_{args.ring_size}_{formatted_prompt}_{formatted_time}" + suffix
+            safe_size = args.size.replace("*", "x")
+            args.save_file = f"{args.task}_{safe_size}_{args.ulysses_size}_{args.ring_size}_{formatted_prompt}_{formatted_time}" + suffix
 
         if "t2i" in args.task:
             logging.info(f"Saving generated image to {args.save_file}")


### PR DESCRIPTION
Fixed the issue that the generated MP4 file name is not supported under Windows:

[2025-03-06 08:41:26,734] INFO: Saving generated video to t2v-1.3B_832*480_1_1_Two_anthropomorphic_cats_in_comfy_boxing_gear_and__20250306_084126.mp4
[out#0/mp4 @ 000001bf503857c0] Error opening output E:\t2v-1.3B_832*480_1_1_Two_anthropomorphic_cats_in_comfy_boxing_gear_and__20250306_084126.mp4: Invalid argument
Error opening output file E:\t2v-1.3B_832*480_1_1_Two_anthropomorphic_cats_in_comfy_boxing_gear_and__20250306_084126.mp4.
Error opening output files: Invalid argument
cache_video failed, error: result type Float can't be cast to the desired output type Byte
