### PR TITLE
Add Windows-specific installation instructions and requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ Install dependencies:
 pip install -r requirements.txt
 ```
 
+for windows:
+
+```sh
+pip install -r requirements-win.txt
+```
 
 #### Model Download
 

--- a/requirements-win.txt
+++ b/requirements-win.txt
@@ -1,0 +1,25 @@
+# PyTorch + TorchVision (CUDA 12.8 build for Windows)
+--extra-index-url https://download.pytorch.org/whl/cu128
+
+torch
+torchvision
+
+
+# Core dependencies
+opencv-python>=4.9.0.80
+diffusers>=0.31.0
+transformers>=4.49.0
+tokenizers>=0.20.3
+accelerate>=1.1.1
+tqdm
+imageio
+easydict
+ftfy
+dashscope
+imageio-ffmpeg
+gradio>=5.0.0
+numpy>=1.23.5,<2
+
+# Known issue:
+# flash_attn is not supported on Windows (fails to build).
+# Users can skip it or run the project in WSL/Linux if needed.


### PR DESCRIPTION
This PR adds official support for **Windows 10/11** by providing:

* A dedicated `requirements-win.txt` with Windows-compatible dependencies.
* Updated README with a **Windows Installation Guide**.
* Instructions for installing PyTorch with CUDA on Windows.
* Notes on known incompatibilities (e.g., `flash_attn` not supported).

**Motivation:**
Current installation fails on Windows due to CPU-only PyTorch and build issues. This update simplifies setup and improves adoption for Windows users.

**System Tested:**

* Windows 11 Pro 64-bit
* NVIDIA RTX (CUDA 12.8)
* Python 3.10 / 3.11

**Branch:** `update/installation_guide`

**Screenshot of Error:**
<img width="1865" height="622" alt="image" src="https://github.com/user-attachments/assets/a1d1539b-2545-4f7e-a2f6-26d3d6d21731" />
