### PR TITLE
fix: when frame_num is changed from 81 the tensor does not match

### DIFF
--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -207,7 +207,7 @@ class WanI2V:
             generator=seed_g,
             device=self.device)
 
-        msk = torch.ones(1, 81, lat_h, lat_w, device=self.device)
+        msk = torch.ones(1, F, lat_h, lat_w, device=self.device)
         msk[:, 1:] = 0
         msk = torch.concat([
             torch.repeat_interleave(msk[:, 0:1], repeats=4, dim=1), msk[:, 1:]


### PR DESCRIPTION
## issue: i2v when `--frame_num` is set to anything not the default 81

```
torch.concat([msk, y])

^^^^^^^^^^^^^^^^^^^^^^

RuntimeError: Sizes of tensors must match except in dimension 0. Expected size 21 but got size **N** for tensor number 1 in the list.
```
This is due to the `msk.shape` mismatch `y.shape` . Most of the code use `F` or `(F - 1) // 4 + 1` but missed a spot
All tensor