### PR TITLE
Fix WanSelfAttention forward docstring

### DIFF
--- a/wan/modules/model.py
+++ b/wan/modules/model.py
@@ -130,7 +130,8 @@ class WanSelfAttention(nn.Module):
     def forward(self, x, seq_lens, grid_sizes, freqs):
         r"""
         Args:
-            x(Tensor): Shape [B, L, num_heads, C / num_heads]
+            x (Tensor): Input token features of shape [B, L, C], `qkv_fn` then 
+                then reshapes to [B, L, num_heads, C / num_heads] before call to flash_attention
             seq_lens(Tensor): Shape [B]
             grid_sizes(Tensor): Shape [B, 3], the second dimension contains (F, H, W)
             freqs(Tensor): Rope freqs, shape [1024, C / num_heads / 2]


### PR DESCRIPTION
* The `WanSelfAttention.forward` docstring currently states `x` is `[B, L, num_heads, head_dim]`, but the implementation (and callsites) pass `x` as `[B, L, C]` and split into heads after the linear projections (`qkv_fn`).
* This PR updates the docstring to reflect the actual shape.
* No functional changes.