### PR TITLE
fix: use variable frame_num instead of hardcoded 81 in FLF2V mask

### DIFF
--- a/wan/first_last_frame2video.py
+++ b/wan/first_last_frame2video.py
@@ -228,7 +228,7 @@ class WanFLF2V:
             generator=seed_g,
             device=self.device)
 
-        msk = torch.ones(1, 81, lat_h, lat_w, device=self.device)
+        msk = torch.ones(1, F, lat_h, lat_w, device=self.device)
         msk[:, 1:-1] = 0
         msk = torch.concat([
             torch.repeat_interleave(msk[:, 0:1], repeats=4, dim=1), msk[:, 1:]


### PR DESCRIPTION
## Summary

The mask tensor in `WanFLF2V.generate()` (`wan/first_last_frame2video.py`, line 231) was hardcoded with `81` frames:

- Before: `msk = torch.ones(1, 81, lat_h, lat_w, device=self.device)`
- After: `msk = torch.ones(1, F, lat_h, lat_w, device=self.device)`

This causes a tensor dimension mismatch error when `frame_num` is set to any value other than 81.

The same bug was previously fixed in `image2video.py` via PR #533, but `first_last_frame2video.py` was missed.

## Reproduction

Run FLF2V generation with `--frame_num 41` (or any value != 81) → crash due to tensor shape mismatch.

## Test plan

- [x] Verified that the fix matches the pattern used in `image2video.py` (line 210)
- [ ] Run FLF2V generation with default `frame_num=81` to confirm no regression
- [ ] Run FLF2V generation with non-default `frame_num` (e.g., 41) to confirm fix