### PR TITLE
LiteLinear integration example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 *.pdf
 *.whl
 cache
+benchmarks/
 __pycache__/
 storage/
 samples/

--- a/README.md
+++ b/README.md
@@ -99,6 +99,59 @@ Install dependencies:
 pip install -r requirements.txt
 ```
 
+#### Optional LiteLinear FFN integration
+
+This tree expects LiteLinear as an installed optional wheel. The pinned CUDA
+12.8 wheel used by the local I2V checks is:
+
+```sh
+pip install --force-reinstall --no-deps "https://raw.githubusercontent.com/moonmath-ai/LiteLinear/3f3f09bf2dd1775dbf43f4ffe5de4a3cff9a25c7/install/lite_linear-0.2.0%2Bcu128-cp310-cp310-linux_x86_64.whl"
+```
+
+The Wan integration patches the video FFNs and resolves LiteLinear-compatible
+checkpoint shards before `WanModel.from_pretrained()` loads them.
+
+- `run_i2v.sh` shows a working single-GPU image-to-video example.
+- `test_wan_i2v_wheel_matrix.sh` downloads and installs the pinned wheel before
+  running the LiteLinear enabled/disabled and cache-mode matrix.
+- `litelinear.config` is the default Wan FFN filter used by that runner.
+
+WorldJen average scores by prompt:
+
+| Prompt | Metric | Baseline | LiteLinear | Delta |
+| --- | --- | ---: | ---: | ---: |
+| `surf-cat` | subject consistency | 93.33% | 97.50% | +4.17 |
+| `surf-cat` | scene consistency | 96.67% | 98.75% | +2.08 |
+| `surf-cat` | motion smoothness | 75.00% | 98.75% | +23.75 |
+| `surf-cat` | temporal flickering | 86.67% | 98.75% | +12.08 |
+| `surf-cat` | physical mechanics | 84.17% | 96.25% | +12.08 |
+| `surf-cat` | object permanence | 94.17% | 98.75% | +4.58 |
+| `surf-cat` | human fidelity | 91.67% | 98.75% | +7.08 |
+| `surf-cat` | dynamic degree | 56.67% | 87.50% | +30.83 |
+| `surf-cat` | semantic adherence | 100.00% | 100.00% | +0.00 |
+| `surf-cat` | spatial relationship | 94.17% | 100.00% | +5.83 |
+| `surf-cat` | semantic drift | 100.00% | 100.00% | +0.00 |
+| `surf-cat` | total | 88.41% | 97.73% | +9.32 |
+| `angelic-clock` | subject consistency | 87.50% | 86.25% | -1.25 |
+| `angelic-clock` | scene consistency | 88.33% | 83.75% | -4.58 |
+| `angelic-clock` | motion smoothness | 86.67% | 67.50% | -19.17 |
+| `angelic-clock` | temporal flickering | 90.00% | 70.00% | -20.00 |
+| `angelic-clock` | physical mechanics | 85.83% | 65.00% | -20.83 |
+| `angelic-clock` | object permanence | 88.33% | 80.00% | -8.33 |
+| `angelic-clock` | human fidelity | 90.00% | 82.50% | -7.50 |
+| `angelic-clock` | dynamic degree | 7.50% | 26.25% | +18.75 |
+| `angelic-clock` | semantic adherence | 99.17% | 97.50% | -1.67 |
+| `angelic-clock` | spatial relationship | 91.67% | 85.00% | -6.67 |
+| `angelic-clock` | semantic drift | 97.50% | 92.50% | -5.00 |
+| `angelic-clock` | total | 82.95% | 76.02% | -6.93 |
+
+Example:
+```sh
+WAN_I2V_CKPT_DIR=/path/to/Wan2.1-I2V-14B-720P ./run_i2v.sh
+```
+
+The recommended LiteLinear path is strict/offline or online-patched checkpoint
+loading.
 
 #### Model Download
 

--- a/generate.py
+++ b/generate.py
@@ -1,5 +1,6 @@
 # Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
 import argparse
+import copy
 import logging
 import os
 import sys
@@ -87,6 +88,11 @@ def _validate_args(args):
     # T2I frame_num check
     if "t2i" in args.task:
         assert args.frame_num == 1, f"Unsupport frame_num {args.frame_num} for task {args.task}"
+    elif args.frame_num % 4 != 1:
+        raise ValueError(
+            f"Unsupported frame_num {args.frame_num} for task {args.task}. "
+            "Video tasks require frame_num = 4n+1 (for example: 49, 81, 121)."
+        )
 
     args.base_seed = args.base_seed if args.base_seed >= 0 else random.randint(
         0, sys.maxsize)
@@ -243,6 +249,11 @@ def _parse_args():
         type=float,
         default=5.0,
         help="Classifier free guidance scale.")
+    parser.add_argument(
+        "--sample_fps",
+        type=int,
+        default=None,
+        help="Output video FPS override. Defaults to the task config value.")
 
     args = parser.parse_args()
 
@@ -318,7 +329,9 @@ def generate(args):
             raise NotImplementedError(
                 f"Unsupport prompt_extend_method: {args.prompt_extend_method}")
 
-    cfg = WAN_CONFIGS[args.task]
+    cfg = copy.deepcopy(WAN_CONFIGS[args.task])
+    if args.sample_fps is not None:
+        cfg.sample_fps = args.sample_fps
     if args.ulysses_size > 1:
         assert cfg.num_heads % args.ulysses_size == 0, f"`{cfg.num_heads=}` cannot be divided evenly by `{args.ulysses_size=}`."
 

--- a/litelinear.config
+++ b/litelinear.config
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "layer_names": ["ffn"],
+  "include_contains": ["blocks"],
+  "exclude_contains": [],
+  "include_regex": [],
+  "exclude_regex": [],
+  "exact_prefixes": []
+}

--- a/run_i2v.sh
+++ b/run_i2v.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-7}"
+export LITELINEAR_DISABLED="${LITELINEAR_DISABLED:-0}"
+export WAN_I2V_SAMPLE_STEPS="${WAN_I2V_SAMPLE_STEPS:-20}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}"
+LOG_FILE="${WAN_I2V_LOG_FILE:-${REPO_ROOT}/run_i2v.log}"
+export LITELINEAR_ONLINE_PATCH="${LITELINEAR_ONLINE_PATCH:-1}"
+LITELINEAR_SOURCE_ROOT="${WAN_I2V_LITELINEAR_SOURCE_ROOT:-${REPO_ROOT}/LiteLinear}"
+LITELINEAR_SOURCE_ACTIVE=0
+case "${WAN_I2V_USE_LITELINEAR_SOURCE:-0}" in
+  1|true|True|TRUE|yes|Yes|YES|on|On|ON)
+    if [[ ! -d "${LITELINEAR_SOURCE_ROOT}" ]]; then
+      echo "LiteLinear source directory not found: ${LITELINEAR_SOURCE_ROOT}"
+      echo "Install the lite_linear wheel or set WAN_I2V_LITELINEAR_SOURCE_ROOT to a source checkout."
+      exit 1
+    fi
+    export PYTHONPATH="${LITELINEAR_SOURCE_ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
+    LITELINEAR_SOURCE_ACTIVE=1
+    ;;
+esac
+
+# This is the same base prompt used in the Wan README. If prompt extension is
+# enabled, Wan expands this text rather than replacing it from scratch.
+DEFAULT_PROMPT="Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside."
+
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+is_truthy() {
+  case "${1:-}" in
+    1|true|True|TRUE|yes|Yes|YES|on|On|ON)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+if [[ -x "${REPO_ROOT}/.venv/bin/python" ]]; then
+  PYTHON_BIN_DEFAULT="${REPO_ROOT}/.venv/bin/python"
+else
+  PYTHON_BIN_DEFAULT="python3"
+fi
+
+PYTHON_BIN="${WAN_I2V_PYTHON:-${PYTHON_BIN_DEFAULT}}"
+TASK="${WAN_I2V_TASK:-i2v-14B}"
+SIZE="${WAN_I2V_SIZE:-1280*720}"
+if [[ -n "${WAN_I2V_CKPT_DIR:-}" ]]; then
+  CKPT_DIR="${WAN_I2V_CKPT_DIR}"
+  CKPT_ROOT="$(dirname "${CKPT_DIR}")"
+else
+  if [[ -n "${HF_HOME:-}" ]]; then
+    CKPT_ROOT="${HF_HOME}/Wan2.1"
+  else
+    CKPT_ROOT="${REPO_ROOT}"
+  fi
+  mkdir -p "${CKPT_ROOT}"
+  CKPT_DIR="${CKPT_ROOT}/Wan2.1-I2V-14B-720P"
+fi
+LITELINEAR_PATCH_CONFIG_DEFAULT="${REPO_ROOT}/litelinear.config"
+if [[ -z "${LITELINEAR_PATCH_CONFIG:-}" && -f "${LITELINEAR_PATCH_CONFIG_DEFAULT}" ]]; then
+  export LITELINEAR_PATCH_CONFIG="${LITELINEAR_PATCH_CONFIG_DEFAULT}"
+fi
+IMAGE_PATH="${WAN_I2V_IMAGE:-${REPO_ROOT}/surf_cat_ref.jpeg}"
+PROMPT="${WAN_I2V_PROMPT:-${DEFAULT_PROMPT}}"
+FRAME_NUM="${WAN_I2V_FRAME_NUM:-49}"
+OFFLOAD_MODEL="${WAN_I2V_OFFLOAD_MODEL:-False}"
+SAMPLE_FPS="${WAN_I2V_SAMPLE_FPS:-24}"
+USE_PROMPT_EXTEND="${WAN_I2V_USE_PROMPT_EXTEND:-0}"
+PROMPT_EXTEND_METHOD="${WAN_I2V_PROMPT_EXTEND_METHOD:-local_qwen}"
+PROMPT_EXTEND_MODEL="${WAN_I2V_PROMPT_EXTEND_MODEL:-Qwen/Qwen2.5-VL-7B-Instruct}"
+PROMPT_EXTEND_TARGET_LANG="${WAN_I2V_PROMPT_EXTEND_TARGET_LANG:-}"
+FRAME_NUM_REQUESTED="${FRAME_NUM}"
+
+if [[ ! "${FRAME_NUM}" =~ ^[0-9]+$ ]]; then
+  echo "WAN_I2V_FRAME_NUM must be a positive integer, got: ${FRAME_NUM}"
+  exit 1
+fi
+
+if (( FRAME_NUM < 1 )); then
+  echo "WAN_I2V_FRAME_NUM must be >= 1, got: ${FRAME_NUM}"
+  exit 1
+fi
+
+if (( (FRAME_NUM - 1) % 4 != 0 )); then
+  FRAME_NUM=$(( FRAME_NUM + 4 - ((FRAME_NUM - 1) % 4) ))
+  FRAME_NUM_ADJUSTMENT_NOTE="Adjusted frame_num from ${FRAME_NUM_REQUESTED} to ${FRAME_NUM} to satisfy Wan's 4n+1 requirement."
+fi
+
+if [[ ! -f "${REPO_ROOT}/generate.py" ]]; then
+  echo "generate.py not found under ${REPO_ROOT}"
+  exit 1
+fi
+
+if [[ ! -e "${IMAGE_PATH}" ]]; then
+  echo "Input image not found: ${IMAGE_PATH}"
+  exit 1
+fi
+
+if [[ ! -d "${CKPT_DIR}" ]]; then
+  echo "Checkpoint directory not found: ${CKPT_DIR}"
+  if [[ -z "${WAN_I2V_CKPT_DIR:-}" ]]; then
+    echo "Created checkpoint root: ${CKPT_ROOT}"
+  fi
+  echo "Set WAN_I2V_CKPT_DIR to your Wan2.1-I2V checkpoint directory."
+  exit 1
+fi
+
+cd "${REPO_ROOT}"
+mkdir -p "$(dirname "${LOG_FILE}")"
+exec > >(tee -a "${LOG_FILE}") 2>&1
+
+cmd=(
+  "${PYTHON_BIN}"
+  "generate.py"
+  "--task" "${TASK}"
+  "--size" "${SIZE}"
+  "--ckpt_dir" "${CKPT_DIR}"
+  "--frame_num" "${FRAME_NUM}"
+  "--offload_model" "${OFFLOAD_MODEL}"
+  "--sample_fps" "${SAMPLE_FPS}"
+  "--image" "${IMAGE_PATH}"
+  "--prompt" "${PROMPT}"
+)
+
+if is_truthy "${USE_PROMPT_EXTEND}"; then
+  cmd+=(
+    "--use_prompt_extend"
+    "--prompt_extend_method" "${PROMPT_EXTEND_METHOD}"
+  )
+  if [[ "${PROMPT_EXTEND_METHOD}" == "local_qwen" ]]; then
+    cmd+=("--prompt_extend_model" "${PROMPT_EXTEND_MODEL}")
+  fi
+  if [[ -n "${PROMPT_EXTEND_TARGET_LANG}" ]]; then
+    cmd+=("--prompt_extend_target_lang" "${PROMPT_EXTEND_TARGET_LANG}")
+  fi
+fi
+
+if [[ -n "${WAN_I2V_SAVE_FILE:-}" ]]; then
+  cmd+=("--save_file" "${WAN_I2V_SAVE_FILE}")
+fi
+
+if [[ -n "${WAN_I2V_BASE_SEED:-}" ]]; then
+  cmd+=("--base_seed" "${WAN_I2V_BASE_SEED}")
+fi
+
+if [[ -n "${WAN_I2V_SAMPLE_STEPS:-40}" ]]; then
+  cmd+=("--sample_steps" "${WAN_I2V_SAMPLE_STEPS}")
+fi
+
+if [[ -n "${WAN_I2V_SAMPLE_GUIDE_SCALE:-}" ]]; then
+  cmd+=("--sample_guide_scale" "${WAN_I2V_SAMPLE_GUIDE_SCALE}")
+fi
+
+if [[ -n "${WAN_I2V_SAMPLE_SHIFT:-}" ]]; then
+  cmd+=("--sample_shift" "${WAN_I2V_SAMPLE_SHIFT}")
+fi
+
+cmd+=("$@")
+
+printf -v COMMAND_LINE '%q ' "${cmd[@]}"
+COMMAND_LINE="${COMMAND_LINE% }"
+
+echo
+echo "========================================="
+echo "run_i2v.sh ($(timestamp))"
+echo "log_file=${LOG_FILE}"
+echo "python=${PYTHON_BIN}"
+echo "task=${TASK}"
+echo "size=${SIZE}"
+echo "ckpt_root=${CKPT_ROOT}"
+echo "ckpt_dir=${CKPT_DIR}"
+echo "frame_num=${FRAME_NUM}"
+if [[ -n "${FRAME_NUM_ADJUSTMENT_NOTE:-}" ]]; then
+  echo "${FRAME_NUM_ADJUSTMENT_NOTE}"
+fi
+if [[ -n "${LITELINEAR_PATCH_CONFIG:-}" ]]; then
+  echo "litelinear_patch_config=${LITELINEAR_PATCH_CONFIG}"
+fi
+echo "litelinear_disabled=${LITELINEAR_DISABLED}"
+echo "litelinear_online_patch=${LITELINEAR_ONLINE_PATCH}"
+echo "litelinear_cache=${LITELINEAR_CACHE:-}"
+echo "litelinear_source=${LITELINEAR_SOURCE_ACTIVE}"
+if [[ "${LITELINEAR_SOURCE_ACTIVE}" -eq 1 ]]; then
+  echo "litelinear_source_root=${LITELINEAR_SOURCE_ROOT}"
+fi
+echo "offload_model=${OFFLOAD_MODEL}"
+echo "sample_fps=${SAMPLE_FPS}"
+echo "image=${IMAGE_PATH}"
+echo "prompt_extend=${USE_PROMPT_EXTEND}"
+if is_truthy "${USE_PROMPT_EXTEND}"; then
+  echo "prompt_extend_method=${PROMPT_EXTEND_METHOD}"
+  if [[ "${PROMPT_EXTEND_METHOD}" == "local_qwen" ]]; then
+    echo "prompt_extend_model=${PROMPT_EXTEND_MODEL}"
+  fi
+  if [[ -n "${PROMPT_EXTEND_TARGET_LANG}" ]]; then
+    echo "prompt_extend_target_lang=${PROMPT_EXTEND_TARGET_LANG}"
+  fi
+fi
+echo "command=${COMMAND_LINE}"
+echo "========================================="
+
+"${cmd[@]}"

--- a/test_wan_i2v_wheel_matrix.sh
+++ b/test_wan_i2v_wheel_matrix.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}"
+LITELINEAR_WHEEL_URL="${LITELINEAR_WHEEL_URL:-https://raw.githubusercontent.com/moonmath-ai/LiteLinear/3f3f09bf2dd1775dbf43f4ffe5de4a3cff9a25c7/install/lite_linear-0.2.0%2Bcu128-cp310-cp310-linux_x86_64.whl}"
+
+PY_BIN="${WAN_WHEEL_MATRIX_PYTHON:-/root/miniconda3/envs/wan2114b-ll/bin/python}"
+OUTPUT_ROOT="${WAN_WHEEL_MATRIX_OUTPUT_ROOT:-${REPO_ROOT}/benchmarks/wan_i2v_wheel_matrix_$(date -u +%Y%m%d_%H%M%S)}"
+WHEELHOUSE="${OUTPUT_ROOT}/wheelhouse"
+CACHE_BASE="${WAN_WHEEL_MATRIX_CACHE_BASE:-${OUTPUT_ROOT}/litelinear_cache}"
+if [[ -z "${WAN_I2V_CKPT_DIR:-}" ]]; then
+  if [[ -d "${REPO_ROOT}/Wan2.1-I2V-14B-720P" ]]; then
+    WAN_I2V_CKPT_DIR="${REPO_ROOT}/Wan2.1-I2V-14B-720P"
+  elif [[ -n "${HF_HOME:-}" && -d "${HF_HOME}/Wan2.1/Wan2.1-I2V-14B-720P" ]]; then
+    WAN_I2V_CKPT_DIR="${HF_HOME}/Wan2.1/Wan2.1-I2V-14B-720P"
+  elif [[ -f "/data/huggingface_cache/Wan2.1/config.json" && -f "/data/huggingface_cache/Wan2.1/diffusion_pytorch_model.safetensors.index.json" ]]; then
+    WAN_I2V_CKPT_DIR="/data/huggingface_cache/Wan2.1"
+  else
+    WAN_I2V_CKPT_DIR="/data/huggingface_cache/Wan2.1/Wan2.1-I2V-14B-720P"
+  fi
+fi
+
+FRAME_NUM="${WAN_WHEEL_MATRIX_FRAME_NUM:-9}"
+SAMPLE_STEPS="${WAN_WHEEL_MATRIX_SAMPLE_STEPS:-10}"
+SAMPLE_FPS="${WAN_WHEEL_MATRIX_SAMPLE_FPS:-16}"
+CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-7}"
+
+if [[ ! -x "${PY_BIN}" ]]; then
+  echo "Python not executable: ${PY_BIN}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${REPO_ROOT}/run_i2v.sh" ]]; then
+  echo "run_i2v.sh not found under ${REPO_ROOT}" >&2
+  exit 1
+fi
+
+if [[ ! -d "${WAN_I2V_CKPT_DIR}" ]]; then
+  echo "Checkpoint directory not found: ${WAN_I2V_CKPT_DIR}" >&2
+  echo "Set WAN_I2V_CKPT_DIR to your Wan2.1-I2V-14B-720P directory." >&2
+  exit 1
+fi
+
+mkdir -p "${WHEELHOUSE}" "${CACHE_BASE}"
+MATRIX_LOG="${WAN_WHEEL_MATRIX_LOG_FILE:-${OUTPUT_ROOT}/matrix.log}"
+touch "${MATRIX_LOG}"
+exec > >(tee -a "${MATRIX_LOG}") 2>&1
+
+echo "[wheel-matrix] repo_root=${REPO_ROOT}"
+echo "[wheel-matrix] litelinear_wheel_url=${LITELINEAR_WHEEL_URL}"
+echo "[wheel-matrix] python=${PY_BIN}"
+echo "[wheel-matrix] ckpt_dir=${WAN_I2V_CKPT_DIR}"
+echo "[wheel-matrix] output_root=${OUTPUT_ROOT}"
+echo "[wheel-matrix] matrix_log=${MATRIX_LOG}"
+echo "[wheel-matrix] frame_num=${FRAME_NUM} sample_steps=${SAMPLE_STEPS} sample_fps=${SAMPLE_FPS}"
+
+echo "[wheel-matrix] downloading LiteLinear wheel"
+WHEEL_PATH="$("${PY_BIN}" - "${LITELINEAR_WHEEL_URL}" "${WHEELHOUSE}" <<'PY'
+import pathlib
+import sys
+import urllib.parse
+import urllib.request
+import zipfile
+
+url = sys.argv[1]
+wheelhouse = pathlib.Path(sys.argv[2])
+wheelhouse.mkdir(parents=True, exist_ok=True)
+
+filename = pathlib.Path(urllib.parse.unquote(urllib.parse.urlparse(url).path)).name
+if not filename.endswith(".whl"):
+    filename = "lite_linear-0.2.0+cu128-cp310-cp310-linux_x86_64.whl"
+target = wheelhouse / filename
+
+request = urllib.request.Request(url, headers={"User-Agent": "Wan2.1 wheel matrix"})
+with urllib.request.urlopen(request) as response:
+    target.write_bytes(response.read())
+
+if not zipfile.is_zipfile(target):
+    raise SystemExit(f"Downloaded LiteLinear wheel is not a valid wheel archive: {target}")
+print(target)
+PY
+)"
+
+echo "[wheel-matrix] installing ${WHEEL_PATH}"
+"${PY_BIN}" -m pip install --force-reinstall --no-deps "${WHEEL_PATH}"
+
+echo "[wheel-matrix] verifying wheel import is not from the repo tree"
+PYTHONPATH="" REPO_ROOT="${REPO_ROOT}" "${PY_BIN}" <<'PY'
+import os
+import pathlib
+
+import lite_linear
+import lite_linear._cuda as litelinear_cuda
+
+repo_root = pathlib.Path(os.environ["REPO_ROOT"]).resolve()
+package_file = pathlib.Path(lite_linear.__file__).resolve()
+cuda_file = pathlib.Path(litelinear_cuda.__file__).resolve()
+print("lite_linear:", package_file)
+print("lite_linear._cuda:", cuda_file)
+if repo_root == package_file or repo_root in package_file.parents:
+    raise SystemExit(f"lite_linear imported from repo tree: {package_file}")
+if repo_root == cuda_file or repo_root in cuda_file.parents:
+    raise SystemExit(f"lite_linear._cuda imported from repo tree: {cuda_file}")
+PY
+
+SUMMARY_TSV="${OUTPUT_ROOT}/matrix_summary.tsv"
+printf "case\tdisabled\tonline_patch\tcache_state\texpected\tstatus\n" > "${SUMMARY_TSV}"
+
+ensure_cache_present() {
+  local cache_dir="${CACHE_BASE}/present"
+  if [[ -d "${cache_dir}/patched_model_dirs" || -d "${cache_dir}/patched_models" ]]; then
+    echo "${cache_dir}"
+    return 0
+  fi
+
+  echo "[wheel-matrix] preparing cache-present state with one online-patch smoke run" >&2
+  rm -rf "${cache_dir}"
+  mkdir -p "${cache_dir}"
+  local prep_dir="${OUTPUT_ROOT}/_prepare_cache_present"
+  mkdir -p "${prep_dir}"
+  env \
+    CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES}" \
+    PYTHONPATH="" \
+    WAN_I2V_CKPT_DIR="${WAN_I2V_CKPT_DIR}" \
+    WAN_I2V_PYTHON="${PY_BIN}" \
+    WAN_I2V_USE_LITELINEAR_SOURCE=0 \
+    WAN_I2V_FRAME_NUM="${FRAME_NUM}" \
+    WAN_I2V_SAMPLE_STEPS="${SAMPLE_STEPS}" \
+    WAN_I2V_SAMPLE_FPS="${SAMPLE_FPS}" \
+    WAN_I2V_LOG_FILE="${prep_dir}/run_i2v.log" \
+    WAN_I2V_SAVE_FILE="${prep_dir}/out.mp4" \
+    LITELINEAR_CACHE="${cache_dir}" \
+    LITELINEAR_DISABLED=0 \
+    LITELINEAR_ONLINE_PATCH=1 \
+    "${REPO_ROOT}/run_i2v.sh" >&2
+  echo "${cache_dir}"
+}
+
+run_case() {
+  local disabled="$1"
+  local online_patch="$2"
+  local cache_state="$3"
+  local expected="$4"
+
+  local case_name="disabled${disabled}_online${online_patch}_cache${cache_state}"
+  local case_dir="${OUTPUT_ROOT}/${case_name}"
+  local cache_dir
+
+  mkdir -p "${case_dir}"
+  if [[ "${cache_state}" == "present" ]]; then
+    cache_dir="$(ensure_cache_present)"
+  else
+    cache_dir="${CACHE_BASE}/${case_name}"
+    rm -rf "${cache_dir}"
+    mkdir -p "${cache_dir}"
+  fi
+
+  echo "[wheel-matrix] case=${case_name} expected=${expected}"
+  set +e
+  env \
+    CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES}" \
+    PYTHONPATH="" \
+    WAN_I2V_CKPT_DIR="${WAN_I2V_CKPT_DIR}" \
+    WAN_I2V_PYTHON="${PY_BIN}" \
+    WAN_I2V_USE_LITELINEAR_SOURCE=0 \
+    WAN_I2V_FRAME_NUM="${FRAME_NUM}" \
+    WAN_I2V_SAMPLE_STEPS="${SAMPLE_STEPS}" \
+    WAN_I2V_SAMPLE_FPS="${SAMPLE_FPS}" \
+    WAN_I2V_LOG_FILE="${case_dir}/run_i2v.log" \
+    WAN_I2V_SAVE_FILE="${case_dir}/out.mp4" \
+    LITELINEAR_CACHE="${cache_dir}" \
+    LITELINEAR_DISABLED="${disabled}" \
+    LITELINEAR_ONLINE_PATCH="${online_patch}" \
+    "${REPO_ROOT}/run_i2v.sh"
+  local rc=$?
+  set -e
+
+  local status="fail"
+  if [[ "${rc}" -eq 0 ]]; then
+    status="pass"
+  fi
+  printf "%s\t%s\t%s\t%s\t%s\t%s\n" "${case_name}" "${disabled}" "${online_patch}" "${cache_state}" "${expected}" "${status}" >> "${SUMMARY_TSV}"
+
+  if [[ "${expected}" == "pass" && "${status}" != "pass" ]]; then
+    echo "[wheel-matrix] unexpected failure in ${case_name}; see ${case_dir}/run_i2v.log" >&2
+    return 1
+  fi
+  if [[ "${expected}" == "fail" && "${status}" != "fail" ]]; then
+    echo "[wheel-matrix] unexpected success in ${case_name}; expected strict cached mode to fail without cache" >&2
+    return 1
+  fi
+  return 0
+}
+
+# Matrix:
+# - disabled=1 should use dense/original weights regardless of online-patch or cache.
+# - disabled=0, online=1 should build/reuse patched cache and pass.
+# - disabled=0, online=0 is strict cached mode: pass only when cache is present.
+run_case 1 0 absent pass
+run_case 1 0 present pass
+run_case 1 1 absent pass
+run_case 1 1 present pass
+run_case 0 1 absent pass
+run_case 0 1 present pass
+run_case 0 0 absent fail
+run_case 0 0 present pass
+
+echo "[wheel-matrix] wrote ${SUMMARY_TSV}"
+echo "[wheel-matrix] full log: ${MATRIX_LOG}"
+cat "${SUMMARY_TSV}"

--- a/wan/first_last_frame2video.py
+++ b/wan/first_last_frame2video.py
@@ -18,7 +18,7 @@ from tqdm import tqdm
 
 from .distributed.fsdp import shard_model
 from .modules.clip import CLIPModel
-from .modules.model import WanModel
+from .modules.model import WanModel, assign_litelinear_module_keys
 from .modules.t5 import T5EncoderModel
 from .modules.vae import WanVAE
 from .utils.fm_solvers import (
@@ -100,7 +100,8 @@ class WanFLF2V:
 
         logging.info(f"Creating WanModel from {checkpoint_dir}")
         self.model = WanModel.from_pretrained(checkpoint_dir)
-        self.model.eval().requires_grad_(False)
+        assign_litelinear_module_keys(self.model)
+        self.model.requires_grad_(False)
 
         if t5_fsdp or dit_fsdp or use_usp:
             init_on_cpu = False
@@ -127,6 +128,7 @@ class WanFLF2V:
         else:
             if not init_on_cpu:
                 self.model.to(self.device)
+                self.model.eval()
 
         self.sample_neg_prompt = config.sample_neg_prompt
 
@@ -326,6 +328,7 @@ class WanFLF2V:
                 torch.cuda.empty_cache()
 
             self.model.to(self.device)
+            self.model.eval()
             for _, t in enumerate(tqdm(timesteps)):
                 latent_model_input = [latent.to(self.device)]
                 timestep = [t]

--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -18,7 +18,7 @@ from tqdm import tqdm
 
 from .distributed.fsdp import shard_model
 from .modules.clip import CLIPModel
-from .modules.model import WanModel
+from .modules.model import WanModel, assign_litelinear_module_keys
 from .modules.t5 import T5EncoderModel
 from .modules.vae import WanVAE
 from .utils.fm_solvers import (
@@ -100,7 +100,8 @@ class WanI2V:
 
         logging.info(f"Creating WanModel from {checkpoint_dir}")
         self.model = WanModel.from_pretrained(checkpoint_dir)
-        self.model.eval().requires_grad_(False)
+        assign_litelinear_module_keys(self.model)
+        self.model.requires_grad_(False)
 
         if t5_fsdp or dit_fsdp or use_usp:
             init_on_cpu = False
@@ -127,6 +128,7 @@ class WanI2V:
         else:
             if not init_on_cpu:
                 self.model.to(self.device)
+                self.model.eval()
 
         self.sample_neg_prompt = config.sample_neg_prompt
 
@@ -299,6 +301,7 @@ class WanI2V:
                 torch.cuda.empty_cache()
 
             self.model.to(self.device)
+            self.model.eval()
             for _, t in enumerate(tqdm(timesteps)):
                 latent_model_input = [latent.to(self.device)]
                 timestep = [t]

--- a/wan/modules/attention.py
+++ b/wan/modules/attention.py
@@ -93,7 +93,7 @@ def flash_attention(
     # apply attention
     if (version is None or version == 3) and FLASH_ATTN_3_AVAILABLE:
         # Note: dropout_p, window_size are not supported in FA3 now.
-        x = flash_attn_interface.flash_attn_varlen_func(
+        fa3_out = flash_attn_interface.flash_attn_varlen_func(
             q=q,
             k=k,
             v=v,
@@ -107,7 +107,12 @@ def flash_attention(
             max_seqlen_k=lk,
             softmax_scale=softmax_scale,
             causal=causal,
-            deterministic=deterministic)[0].unflatten(0, (b, lq))
+            deterministic=deterministic)
+        # Some FA3 builds return the output tensor directly, while others may
+        # return a tuple whose first item is the output tensor.
+        if isinstance(fa3_out, tuple):
+            fa3_out = fa3_out[0]
+        x = fa3_out.unflatten(0, (b, lq))
     else:
         assert FLASH_ATTN_2_AVAILABLE
         x = flash_attn.flash_attn_varlen_func(

--- a/wan/modules/model.py
+++ b/wan/modules/model.py
@@ -1,5 +1,11 @@
 # Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+import hashlib
+import json
 import math
+import os
+import shutil
+import warnings
+from pathlib import Path
 
 import torch
 import torch.cuda.amp as amp
@@ -9,10 +15,247 @@ from diffusers.models.modeling_utils import ModelMixin
 
 from .attention import flash_attention
 
+try:
+    from lite_linear import LiteLinear
+except Exception as exc:  # pragma: no cover - optional dependency
+    LiteLinear = None
+    _LITELINEAR_IMPORT_ERROR = exc
+    _LITELINEAR_PATCH_HELPERS_ERROR = exc
+    _litelinear_default_cache_root = None
+    _litelinear_resolve_or_build_patched_checkpoint = None
+    _litelinear_resolve_strict_checkpoint_path = None
+    _litelinear_safe_open_for_patch_build = None
+else:
+    _LITELINEAR_IMPORT_ERROR = None
+    try:
+        from lite_linear.checkpoint_patch_core import (
+            default_cache_root as _litelinear_default_cache_root,
+            resolve_or_build_patched_checkpoint as _litelinear_resolve_or_build_patched_checkpoint,
+            resolve_strict_checkpoint_path as _litelinear_resolve_strict_checkpoint_path,
+        )
+        from lite_linear.patched_checkpoint import (
+            get_safe_open_for_patch_build as _litelinear_safe_open_for_patch_build,
+        )
+    except Exception as exc:  # pragma: no cover - optional dependency
+        _LITELINEAR_PATCH_HELPERS_ERROR = exc
+        _litelinear_default_cache_root = None
+        _litelinear_resolve_or_build_patched_checkpoint = None
+        _litelinear_resolve_strict_checkpoint_path = None
+        _litelinear_safe_open_for_patch_build = None
+    else:
+        _LITELINEAR_PATCH_HELPERS_ERROR = None
+
 __all__ = ['WanModel']
 
 T5_CONTEXT_TOKEN_NUMBER = 512
 FIRST_LAST_FRAME_CONTEXT_TOKEN_NUMBER = 257 * 2
+_BOOL_TRUE = {"1", "true", "yes", "y", "on"}
+
+
+def _env_true(name, default="0"):
+    return os.environ.get(name, default).strip().lower() in _BOOL_TRUE
+
+
+def _litelinear_disabled():
+    return _env_true("LITELINEAR_DISABLED", "0")
+
+
+def _litelinear_online_patch_enabled():
+    return (not _litelinear_disabled()) and _env_true("LITELINEAR_ONLINE_PATCH", "0")
+
+
+def _litelinear_strict_mode_enabled():
+    return (not _litelinear_disabled()) and (not _litelinear_online_patch_enabled())
+
+
+def _litelinear_patch_tag():
+    tag = os.environ.get("LITELINEAR_PATCH_TAG", "nocalib").strip().lower()
+    return "calib" if tag == "calib" else "nocalib"
+
+
+def _litelinear_patch_config_path():
+    raw = os.environ.get("LITELINEAR_PATCH_CONFIG", "").strip()
+    if not raw:
+        return None
+    return Path(raw).expanduser().resolve()
+
+
+def _sync_file_reference(src: Path, dst: Path):
+    src = src.resolve()
+    if dst.is_symlink():
+        try:
+            if dst.resolve() == src:
+                return
+        except FileNotFoundError:
+            pass
+        dst.unlink(missing_ok=True)
+    elif dst.exists():
+        if dst.resolve() == src:
+            return
+        dst.unlink()
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.symlink(src, dst)
+    except OSError:
+        shutil.copy2(src, dst)
+
+
+def _litelinear_cached_patched_dir_ready(
+        patched_dir: Path,
+        *,
+        index_name: str,
+        config_name: str,
+        original_weight_map: dict):
+    patched_index_path = patched_dir / index_name
+    patched_config_path = patched_dir / config_name
+    if not patched_index_path.is_file() or not patched_config_path.exists():
+        return False
+    try:
+        patched_data = json.loads(patched_index_path.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    patched_weight_map = patched_data.get("weight_map")
+    if not isinstance(patched_weight_map, dict) or not patched_weight_map:
+        return False
+    # If the cached index is identical to the original one, no shard remap was
+    # applied and the original checkpoint directory should still be used.
+    if patched_weight_map == original_weight_map:
+        return False
+    for shard_name in {str(name) for name in patched_weight_map.values()}:
+        if not (patched_dir / shard_name).is_file():
+            return False
+    return True
+
+
+def _resolve_litelinear_pretrained_dir(pretrained_model_name_or_path):
+    if LiteLinear is None or _LITELINEAR_PATCH_HELPERS_ERROR is not None:
+        return pretrained_model_name_or_path
+    if not (_litelinear_online_patch_enabled() or _litelinear_strict_mode_enabled()):
+        return pretrained_model_name_or_path
+
+    try:
+        checkpoint_dir = Path(pretrained_model_name_or_path).expanduser().resolve()
+    except Exception:
+        return pretrained_model_name_or_path
+
+    index_path = checkpoint_dir / "diffusion_pytorch_model.safetensors.index.json"
+    config_path = checkpoint_dir / "config.json"
+    if not checkpoint_dir.is_dir() or not index_path.is_file() or not config_path.is_file():
+        return pretrained_model_name_or_path
+
+    data = json.loads(index_path.read_text(encoding="utf-8"))
+    weight_map = data.get("weight_map")
+    if not isinstance(weight_map, dict) or not weight_map:
+        return pretrained_model_name_or_path
+
+    rank = int(getattr(LiteLinear, "DEFAULT_RANK", 64))
+    tag = _litelinear_patch_tag()
+    config_filter_path = _litelinear_patch_config_path()
+    config_filter_digest = "none"
+    if config_filter_path is not None:
+        if config_filter_path.is_file():
+            config_filter_digest = hashlib.sha1(
+                config_filter_path.read_bytes()).hexdigest()[:16]
+        else:
+            config_filter_digest = hashlib.sha1(
+                str(config_filter_path).encode()).hexdigest()[:16]
+    mode = "online" if _litelinear_online_patch_enabled() else "strict"
+    dir_key = hashlib.sha1(
+        f"{checkpoint_dir}|mode={mode}|rank={rank}|tag={tag}|cfg={config_filter_digest}".encode()
+    ).hexdigest()[:16]
+    cache_root = _litelinear_default_cache_root()
+    patched_dir = cache_root / "patched_model_dirs" / dir_key
+    patched_dir.mkdir(parents=True, exist_ok=True)
+    if _litelinear_cached_patched_dir_ready(
+            patched_dir,
+            index_name=index_path.name,
+            config_name=config_path.name,
+            original_weight_map=weight_map):
+        print(
+            f"[LiteLinear] WanModel will reuse cached patched shards from {patched_dir}",
+            flush=True,
+        )
+        return patched_dir
+
+    resolve_shard = (
+        _litelinear_resolve_or_build_patched_checkpoint
+        if _litelinear_online_patch_enabled()
+        else _litelinear_resolve_strict_checkpoint_path
+    )
+    safe_open_fn = _litelinear_safe_open_for_patch_build()
+    shard_name_map = {}
+    patched_weight_map = {}
+    patched_count = 0
+    for shard_name in sorted({str(name) for name in weight_map.values()}):
+        src_shard = checkpoint_dir / shard_name
+        resolved = resolve_shard(
+            src_shard,
+            rank=rank,
+            tag=tag,
+            cache_root=cache_root,
+            safe_open_fn=safe_open_fn,
+            log_prefix="[LiteLinear]",
+            patch_config_path=config_filter_path,
+            copy_original=_env_true("LITELINEAR_PATCH_COPY_ORIGINAL", "1"),
+            force_rebuild=_env_true("LITELINEAR_PATCH_FORCE_REBUILD", "0"),
+        ) if _litelinear_online_patch_enabled() else resolve_shard(
+            src_shard,
+            rank=rank,
+            tag=tag,
+            safe_open_fn=safe_open_fn,
+            cache_root=cache_root,
+            log_prefix="[LiteLinear]",
+            patch_config_path=config_filter_path,
+        )
+        shard_name_map[shard_name] = resolved.name
+        if resolved.name != shard_name:
+            patched_count += 1
+        _sync_file_reference(resolved, patched_dir / resolved.name)
+        with safe_open_fn(str(resolved), framework="pt", device="cpu") as shard_file:
+            for key in shard_file.keys():
+                patched_weight_map[str(key)] = resolved.name
+
+    patched_index = dict(data)
+    patched_index["weight_map"] = patched_weight_map
+    (patched_dir / index_path.name).write_text(
+        json.dumps(patched_index, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    _sync_file_reference(config_path, patched_dir / config_path.name)
+
+    if patched_count:
+        print(
+            f"[LiteLinear] WanModel will load patched shards from {patched_dir} "
+            f"({patched_count}/{len(shard_name_map)} shard files remapped)",
+            flush=True,
+        )
+        return patched_dir
+    return pretrained_model_name_or_path
+
+
+def _build_video_ffn_linear(in_features, out_features):
+    if LiteLinear is None:
+        warnings.warn(
+            "lite_linear could not be imported for Wan video FFNs; "
+            f"falling back to nn.Linear ({_LITELINEAR_IMPORT_ERROR}).",
+            RuntimeWarning)
+        return nn.Linear(in_features, out_features)
+    # Use LiteLinear's native controls:
+    # - LITELINEAR_DISABLED=1 to keep original linear weights active
+    # - LiteLinear.DEFAULT_RANK to change the default decomposition rank
+    return LiteLinear(in_features, out_features)
+
+
+def assign_litelinear_module_keys(module):
+    if LiteLinear is None:
+        return 0
+
+    assigned = 0
+    for name, submodule in module.named_modules():
+        if isinstance(submodule, LiteLinear):
+            submodule._lite_key = name
+            assigned += 1
+    return assigned
 
 
 def sinusoidal_embedding_1d(dim, position):
@@ -268,9 +511,13 @@ class WanAttentionBlock(nn.Module):
                                                                       qk_norm,
                                                                       eps)
         self.norm2 = WanLayerNorm(dim, eps)
+        # Keep LiteLinear restricted to the video FFN path only.
+        # No replace_activation_proj_ needed here because Wan uses explicit
+        # linear -> GELU -> linear, unlike wrapped activation-projection blocks.
         self.ffn = nn.Sequential(
-            nn.Linear(dim, ffn_dim), nn.GELU(approximate='tanh'),
-            nn.Linear(ffn_dim, dim))
+            _build_video_ffn_linear(dim, ffn_dim),
+            nn.GELU(approximate='tanh'),
+            _build_video_ffn_linear(ffn_dim, dim))
 
         # modulation
         self.modulation = nn.Parameter(torch.randn(1, 6, dim) / dim**0.5)
@@ -489,6 +736,26 @@ class WanModel(ModelMixin, ConfigMixin):
 
         # initialize weights
         self.init_weights()
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
+        resolved = _resolve_litelinear_pretrained_dir(pretrained_model_name_or_path)
+        patched = str(resolved) != str(pretrained_model_name_or_path)
+        if patched:
+            kwargs = dict(kwargs)
+            # Patched LiteLinear shards can now use the low-memory loader path;
+            # LiteLinear modules are finalized after load from the populated
+            # factor buffers.
+            kwargs.setdefault("low_cpu_mem_usage", True)
+        model = super().from_pretrained(resolved, *model_args, **kwargs)
+        if patched and LiteLinear is not None:
+            finalized = LiteLinear.finalize_after_fast_load(model)
+            if finalized:
+                print(
+                    f"[LiteLinear] Finalized {finalized} LiteLinear modules after fast load",
+                    flush=True,
+                )
+        return model
 
     def forward(
         self,

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -15,7 +15,7 @@ import torch.distributed as dist
 from tqdm import tqdm
 
 from .distributed.fsdp import shard_model
-from .modules.model import WanModel
+from .modules.model import WanModel, assign_litelinear_module_keys
 from .modules.t5 import T5EncoderModel
 from .modules.vae import WanVAE
 from .utils.fm_solvers import (
@@ -85,7 +85,8 @@ class WanT2V:
 
         logging.info(f"Creating WanModel from {checkpoint_dir}")
         self.model = WanModel.from_pretrained(checkpoint_dir)
-        self.model.eval().requires_grad_(False)
+        assign_litelinear_module_keys(self.model)
+        self.model.requires_grad_(False)
 
         if use_usp:
             from xfuser.core.distributed import get_sequence_parallel_world_size
@@ -108,6 +109,7 @@ class WanT2V:
             self.model = shard_fn(self.model)
         else:
             self.model.to(self.device)
+            self.model.eval()
 
         self.sample_neg_prompt = config.sample_neg_prompt
 
@@ -237,6 +239,7 @@ class WanT2V:
                 timestep = torch.stack(timestep)
 
                 self.model.to(self.device)
+                self.model.eval()
                 noise_pred_cond = self.model(
                     latent_model_input, t=timestep, **arg_c)[0]
                 noise_pred_uncond = self.model(

--- a/wan/vace.py
+++ b/wan/vace.py
@@ -20,6 +20,7 @@ import torchvision.transforms.functional as TF
 from PIL import Image
 from tqdm import tqdm
 
+from .modules.model import assign_litelinear_module_keys
 from .modules.vace_model import VaceWanModel
 from .text2video import (
     FlowDPMSolverMultistepScheduler,
@@ -93,7 +94,8 @@ class WanVace(WanT2V):
 
         logging.info(f"Creating VaceWanModel from {checkpoint_dir}")
         self.model = VaceWanModel.from_pretrained(checkpoint_dir)
-        self.model.eval().requires_grad_(False)
+        assign_litelinear_module_keys(self.model)
+        self.model.requires_grad_(False)
 
         if use_usp:
             from xfuser.core.distributed import get_sequence_parallel_world_size
@@ -122,6 +124,7 @@ class WanVace(WanT2V):
             self.model = shard_fn(self.model)
         else:
             self.model.to(self.device)
+            self.model.eval()
 
         self.sample_neg_prompt = config.sample_neg_prompt
 
@@ -433,6 +436,7 @@ class WanVace(WanT2V):
                 timestep = torch.stack(timestep)
 
                 self.model.to(self.device)
+                self.model.eval()
                 noise_pred_cond = self.model(
                     latent_model_input,
                     t=timestep,
@@ -606,7 +610,8 @@ class WanVaceMP(WanVace):
                 device=gpu)
             logging.info(f"Creating VaceWanModel from {self.checkpoint_dir}")
             model = VaceWanModel.from_pretrained(self.checkpoint_dir)
-            model.eval().requires_grad_(False)
+            assign_litelinear_module_keys(model)
+            model.requires_grad_(False)
 
             if self.use_usp:
                 from xfuser.core.distributed import get_sequence_parallel_world_size
@@ -631,6 +636,7 @@ class WanVaceMP(WanVace):
 
             dist.barrier()
             model = shard_fn(model)
+            model.eval()
             sample_neg_prompt = self.config.sample_neg_prompt
 
             torch.cuda.empty_cache()


### PR DESCRIPTION
### LiteLinear FFN integration

Follow [this doc for detailed info
](https://github.com/moonmath-ai/LiteLinear/blob/3f3f09bf2dd1775dbf43f4ffe5de4a3cff9a25c7/docs/integration_guide.md)
Summary

This tree expects LiteLinear as an installed optional wheel. The pinned CUDA
12.8 wheel used by the local I2V checks is:

```sh
pip install --force-reinstall --no-deps "https://raw.githubusercontent.com/moonmath-ai/LiteLinear/3f3f09bf2dd1775dbf43f4ffe5de4a3cff9a25c7/install/lite_linear-0.2.0%2Bcu128-cp310-cp310-linux_x86_64.whl"
```

The Wan integration patches the video FFNs and resolves LiteLinear-compatible
checkpoint shards before `WanModel.from_pretrained()` loads them.

- `run_i2v.sh` shows a working single-GPU image-to-video example.
- `test_wan_i2v_wheel_matrix.sh` downloads and installs the pinned wheel before
  running the LiteLinear enabled/disabled and cache-mode matrix.
- `litelinear.config` is the default Wan FFN filter used by that runner.

WorldJen average scores by prompt:

| Prompt | Metric | Baseline | LiteLinear | Delta |
| --- | --- | ---: | ---: | ---: |
| `surf-cat` | subject consistency | 93.33% | 97.50% | +4.17 |
| `surf-cat` | scene consistency | 96.67% | 98.75% | +2.08 |
| `surf-cat` | motion smoothness | 75.00% | 98.75% | +23.75 |
| `surf-cat` | temporal flickering | 86.67% | 98.75% | +12.08 |
| `surf-cat` | physical mechanics | 84.17% | 96.25% | +12.08 |
| `surf-cat` | object permanence | 94.17% | 98.75% | +4.58 |
| `surf-cat` | human fidelity | 91.67% | 98.75% | +7.08 |
| `surf-cat` | dynamic degree | 56.67% | 87.50% | +30.83 |
| `surf-cat` | semantic adherence | 100.00% | 100.00% | +0.00 |
| `surf-cat` | spatial relationship | 94.17% | 100.00% | +5.83 |
| `surf-cat` | semantic drift | 100.00% | 100.00% | +0.00 |
| `surf-cat` | total | 88.41% | 97.73% | +9.32 |
| `angelic-clock` | subject consistency | 87.50% | 86.25% | -1.25 |
| `angelic-clock` | scene consistency | 88.33% | 83.75% | -4.58 |
| `angelic-clock` | motion smoothness | 86.67% | 67.50% | -19.17 |
| `angelic-clock` | temporal flickering | 90.00% | 70.00% | -20.00 |
| `angelic-clock` | physical mechanics | 85.83% | 65.00% | -20.83 |
| `angelic-clock` | object permanence | 88.33% | 80.00% | -8.33 |
| `angelic-clock` | human fidelity | 90.00% | 82.50% | -7.50 |
| `angelic-clock` | dynamic degree | 7.50% | 26.25% | +18.75 |
| `angelic-clock` | semantic adherence | 99.17% | 97.50% | -1.67 |
| `angelic-clock` | spatial relationship | 91.67% | 85.00% | -6.67 |
| `angelic-clock` | semantic drift | 97.50% | 92.50% | -5.00 |
| `angelic-clock` | total | 82.95% | 76.02% | -6.93 |

Example:
```sh
WAN_I2V_CKPT_DIR=/path/to/Wan2.1-I2V-14B-720P ./run_i2v.sh
```

The recommended LiteLinear path is strict/offline or online-patched checkpoint
loading.